### PR TITLE
Add native crossvalidation

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest mypy codecov pytest-cov xgboost
+        python -m pip install flake8 pytest mypy pytest-cov xgboost
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |

--- a/examples/1_scripted_example.py
+++ b/examples/1_scripted_example.py
@@ -100,12 +100,10 @@ if __name__ == "__main__":
     processed_datasets = experiment_obj.process_data()
 
     # ... then train our model...
-    trained_model = experiment_obj.train_model(
-        RandomForestClassifier(
-            random_state=model_rs
-        ),  # This is why we have 2 different random states...
+    trained_model = experiment_obj.one_shot_train(
+        RandomForestClassifier,
         processed_datasets,
-        # model_algorithm.hyperparams,  # If this is passed, then cross validation search is performed, but slow.
+        parameters={"random_state": args.model_seed},
     )
 
     # Get the predictions and evaluate the performance.

--- a/examples/2_store_all_models_example.py
+++ b/examples/2_store_all_models_example.py
@@ -105,12 +105,10 @@ if __name__ == "__main__":
     processed_datasets = experiment_obj.process_data()
 
     # ... then train our model...
-    trained_model = experiment_obj.train_model(
-        RandomForestClassifier(
-            random_state=model_rs
-        ),  # This is why we have 2 different random states...
+    trained_model = experiment_obj.one_shot_train(
+        RandomForestClassifier,
         processed_datasets,
-        # model_algorithm.hyperparams,  # If this is passed, then cross validation search is performed, but slow.
+        parameters={"random_state": args.model_seed},
     )
 
     # Get the predictions and evaluate the performance.

--- a/examples/4_initial_filtering_and_binary_class_example.py
+++ b/examples/4_initial_filtering_and_binary_class_example.py
@@ -121,12 +121,10 @@ if __name__ == "__main__":
     processed_datasets = experiment_obj.process_data()
 
     # ... then train our model...
-    trained_model = experiment_obj.train_model(
-        RandomForestClassifier(
-            random_state=model_rs
-        ),  # This is why we have 2 different random states...
+    trained_model = experiment_obj.one_shot_train(
+        RandomForestClassifier,
         processed_datasets,
-        # model_algorithm.hyperparams,  # If this is passed, then cross validation search is performed, but slow.
+        parameters={"random_state": args.model_seed},
     )
 
     # Get the predictions and evaluate the performance.

--- a/examples/5_cv_search_for_hyperparameters.py
+++ b/examples/5_cv_search_for_hyperparameters.py
@@ -113,17 +113,20 @@ if __name__ == "__main__":
     ml_model_data = method_definition_function(classifier=True)
 
     # Now we instantiate the model from the ml_model_data.model attribute...
-    ml_model = ml_model_data.model(random_state=model_rs)
+    ml_model = ml_model_data.model
+
+    model_params = ml_model_data.hyperparams
+    model_params["random_state"] = [args.model_seed]
 
     # ... then train our model. This time pass the ml_model_data hyperparameters to search over (this is a dictionary).
     # By default, if the params are passed, the a form of cross validated search will be performed over the provided
     # parameters. Unless defined otherwise, random search over the hyperparameter space is performed.
-    trained_model = experiment_obj.train_model(
-        ml_model,
+    trained_model = experiment_obj.cv_train(
         processed_datasets,
-        params=ml_model_data.hyperparams,  # If this is passed, then cross validation search is performed, but slow.
-        cv_model="random_search",
-        cv_iterations=20,
+        ml_model,
+        parameters=model_params,  # If this is passed, then cross validation search is performed, but slow.
+        random_search=True,
+        random_iterations=20,
     )
 
     # Get the predictions and evaluate the performance.

--- a/examples/6_regression_pca_example.py
+++ b/examples/6_regression_pca_example.py
@@ -167,13 +167,11 @@ if __name__ == "__main__":
     ml_model_data = method_definition_function(classifier=False)
 
     # Now we instantiate the model from the ml_model_data.model attribute...
-    ml_model = ml_model_data.model(random_state=model_rs)
+    ml_model = ml_model_data.model
 
     # ... then train our model...
-    trained_model = experiment_obj.train_model(
-        ml_model,
-        processed_datasets,
-        # model_algorithm.hyperparams,  # If this is passed, then cross validation search is performed, but slow.
+    trained_model = experiment_obj.one_shot_train(
+        ml_model, processed_datasets, parameters={"random_state": args.model_seed}
     )
 
     # Get the predictions and evaluate the performance.

--- a/examples/7_cvsearch_example.py
+++ b/examples/7_cvsearch_example.py
@@ -1,0 +1,129 @@
+import sys
+from pathlib import Path
+import numpy as np
+from typing import List
+import argparse
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.datasets import load_iris
+from mlexpy import pipeline_utils, experiment
+from from_module_example import IrisPipeline
+
+
+def parse_args(args: List[str]) -> argparse.Namespace:
+
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "-r",
+        "--model_seed",
+        help="What is the model random seed to use?",
+        default=10,
+        type=int,
+    )
+
+    parser.add_argument(
+        "-p",
+        "--process_seed",
+        help="What is the process random seed to use?",
+        default=20,
+        type=int,
+    )
+
+    parser.add_argument(
+        "-f",
+        "--test_frac",
+        help="What is the desired test ratio to use?",
+        default=0.35,
+        type=float,
+    )
+
+    parser.add_argument(
+        "-m",
+        "--model_type",
+        help="What is the model  to use?",
+        choices=["random_forest", "sgdclassifier"],
+        type=str,
+    )
+
+    return parser.parse_args(args)
+
+
+"""An example similar to the notebook previously, here with more complexity shown as a script, and CL runnable"""
+
+if __name__ == "__main__":
+    args = parse_args(sys.argv[1:])
+    # First, set the random seed(s) for the experiment
+
+    model_rs = np.random.RandomState(args.model_seed)
+    process_rs = np.random.RandomState(args.process_seed)
+
+    # First, read in the dataset as a dataframe. Because mlexpy is meant to be an exploratory/experimental tool,
+    # dataframes are preferred for their readability.
+    data = load_iris(as_frame=True)
+    features = data["data"]
+    labels = data["target"]
+
+    # Now, generate the ExperimentSetup object, that splits the dataset for training and testing.
+    experiment_setup = pipeline_utils.get_stratified_train_test_data(
+        train_data=features,
+        label_data=labels,
+        test_frac=args.test_frac,
+        random_state=process_rs,
+    )
+
+    # This provides us with a named tuple, with attributes of .train_data and .test_data
+    # each one with attributes of .obs and .labels. For example...
+    train_label_count = experiment_setup.train_data.labels.shape[0]
+    test_label_count = experiment_setup.test_data.labels.shape[0]
+    total_data_count = features.shape[0]
+
+    print(
+        f"Train labels are {round((total_data_count - train_label_count) / total_data_count * 100, 2)}% of the original data ({train_label_count})."
+    )
+    print(
+        f"Test labels are {round((total_data_count - test_label_count) / total_data_count * 100, 2)}% of the original data ({test_label_count})."
+    )
+
+    # Define the experiment
+    experiment_obj = experiment.ClassifierExperiment(
+        train_setup=experiment_setup.train_data,
+        test_setup=experiment_setup.test_data,
+        model_tag="example_development_model",
+        process_tag="example_development_process",
+        model_dir=Path(__file__).parent,
+        rnd_int=20,
+    )
+
+    experiment_obj.set_pipeline(IrisPipeline)
+
+    # Now begin the experimentation, start with performing the data processing...
+    processed_datasets = experiment_obj.process_data()
+
+    # ... then train our model...
+    trained_model = experiment_obj.cv_train(
+        ml_model=RandomForestClassifier,
+        random_iterations=10,
+        random_search=True,
+        data_setup=processed_datasets,
+        parameters={
+            "n_estimators": [10, 50, 100, 200],
+            "max_depth": [1, 5, 10, 20, 50],
+            "criterion": ["gini", "entropy", "log_loss"],
+        },
+    )
+
+    # Get the predictions and evaluate the performance.
+    predictions = experiment_obj.predict(processed_datasets, trained_model)
+    class_probabilities = experiment_obj.predict(
+        processed_datasets, trained_model, proba=True
+    )
+    results = experiment_obj.evaluate_predictions(
+        processed_datasets.test_data.labels,
+        predictions=predictions,
+        class_probabilities=class_probabilities,
+    )
+
+    # ... also evaluate the ROC based metrics
+    roc_results = experiment_obj.evaluate_roc_metrics(
+        processed_datasets, class_probabilities, trained_model
+    )

--- a/examples/7_cvsearch_example.py
+++ b/examples/7_cvsearch_example.py
@@ -91,7 +91,7 @@ if __name__ == "__main__":
         model_tag="example_development_model",
         process_tag="example_development_process",
         model_dir=Path(__file__).parent,
-        rnd_int=20,
+        rnd_int=args.model_seed,
     )
 
     experiment_obj.set_pipeline(IrisPipeline)
@@ -109,6 +109,7 @@ if __name__ == "__main__":
             "n_estimators": [10, 50, 100, 200],
             "max_depth": [1, 5, 10, 20, 50],
             "criterion": ["gini", "entropy", "log_loss"],
+            "random_state": [args.model_seed],
         },
     )
 

--- a/examples/7_cvsearch_example.py
+++ b/examples/7_cvsearch_example.py
@@ -102,7 +102,7 @@ if __name__ == "__main__":
     # ... then train our model...
     trained_model = experiment_obj.cv_train(
         ml_model=RandomForestClassifier,
-        random_iterations=10,
+        random_iterations=5,
         random_search=True,
         data_setup=processed_datasets,
         parameters={
@@ -124,7 +124,10 @@ if __name__ == "__main__":
         class_probabilities=class_probabilities,
     )
 
-    # ... also evaluate the ROC based metrics
-    roc_results = experiment_obj.evaluate_roc_metrics(
-        processed_datasets, class_probabilities, trained_model
+    # Lastly, we can evaluate the model using cross validation
+    cv_eval = experiment_obj.evaluate_predictions_cross_validation(
+        metric_function=experiment_obj.metric_dict["balanced_accuracy"],
+        predictions=predictions,
+        data=processed_datasets.test_data,
+        random_iterations=10,
     )

--- a/mlexpy/experiment.py
+++ b/mlexpy/experiment.py
@@ -319,7 +319,10 @@ class ExperimentBase:
         )
         logger.info("Performing standard model training.")
 
-        if any(isinstance(value, list) for value in parameters.values()):
+        if any(
+            isinstance(value, Iterable) or isinstance(value, str)
+            for value in parameters.values()
+        ):
             raise (
                 ValueError(
                     f"One of the parameters passed to .one_shot_train() is a list. If working over a variable parameter space use .cv_train(), otherwise, make sure the values in the params dict are all singe values, and not lists."
@@ -367,7 +370,10 @@ class ExperimentBase:
         )
         logger.info("Performing cross validated model training.")
 
-        if any(isinstance(value, list) == False for value in parameters.values()):
+        if any(
+            isinstance(value, list) == False and isinstance(value, str) == True
+            for value in parameters.values()
+        ):
             raise (
                 ValueError(
                     f"One of the parameters passed to .one_shot_train() is NOT a list. Can not search over the parameter space unless all values are lists of possible values. Note: a list of length 1 is valid"

--- a/mlexpy/experiment.py
+++ b/mlexpy/experiment.py
@@ -25,7 +25,7 @@ from sklearn.metrics import (
 )
 
 
-from mlexpy.pipeline_utils import MLSetup, ExperimentSetup, CVSearch
+from mlexpy.pipeline_utils import MLSetup, ExperimentSetup, CrossValidation
 from mlexpy.utils import make_directory
 
 
@@ -374,7 +374,7 @@ class ExperimentBase:
                 )
             )
 
-        cv_searcher = CVSearch(
+        cv_searcher = CrossValidation(
             test_fraction=self.test_cv_split,
             score_function=self.standard_cv_scorer,
             n_splits=random_iterations,

--- a/mlexpy/pipeline_utils.py
+++ b/mlexpy/pipeline_utils.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 import logging
-from typing import Any, Dict, Callable, Union, List, Iterable
+from typing import Any, Dict, Callable, Union, List
 from collections import namedtuple
 from itertools import product
 
@@ -71,32 +71,6 @@ def get_stratified_train_test_data(
         )
 
     return ExperimentSetup(MLSetup(X_train, y_train), MLSetup(X_test, y_test))
-
-
-def cv_report(results: Dict[str, Any], n_top: int = 5) -> None:
-
-    """Print out a cross validation result following sklearn cross validation.
-
-    Parameters
-    ----------
-    results : Dict[str, Any]
-        The dictionary storing cross validation result models, and performance statistics.
-
-    n_top : int
-        The defined number of n top performing results to print out.
-
-    Returns
-    -------
-    None
-    """
-    for i in range(1, n_top + 1):
-        candidates = np.flatnonzero(results["rank_test_score"] == i)
-        for candidate in candidates:
-            print(f"Model with rank: {i}")
-            print(
-                f"""Mean validation score: {results["mean_test_score"][candidate]} (std: {results["std_test_score"][candidate]})"""
-            )
-            print(f"""Parameters: {results["params"][candidate]}\n""")
 
 
 class CVSearch:
@@ -179,16 +153,16 @@ class CVSearch:
         split_indices = list(cv_splitter.split(dataset.obs, dataset.labels))
 
         # Now, setup each model iterations, either as random search or grid search. But default to grid search if less than n_iterations.
-        setups = 1
+        setup_count = 1
         for parameter_values in parameter_space.values():
-            setups *= len(parameter_values)
+            setup_count *= len(parameter_values)
 
-        if random_search and setups > n_iterations:
+        if random_search and setup_count > n_iterations:
             setups = self.get_random_search_setups(parameter_space, n_iterations)
         else:
-            if setups < n_iterations:
+            if setup_count < n_iterations:
                 logger.info(
-                    f"Because there are less possible options ({setups}) than desired iterations ({n_iterations}), doing grid search."
+                    f"Because there are less possible options ({setup_count}) than desired iterations ({n_iterations}), doing grid search."
                 )
             setups = self.get_grid_search_setups(parameter_space)
 
@@ -236,7 +210,7 @@ class CVSearch:
         return setups
 
     def get_grid_search_setups(
-        self, parameter_space: Dict[str, Iterable]
+        self, parameter_space: Dict[str, List[Union[int, float, str]]]
     ) -> List[Dict[str, Union[float, int, str]]]:
         """
         Create the parameter definitions over in a grid.

--- a/mlexpy/pipeline_utils.py
+++ b/mlexpy/pipeline_utils.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 import logging
-from typing import Any, Dict, Callable, Any, Iterable, Union, List, Tuple
+from typing import Any, Dict, Callable, Union, List
 from collections import namedtuple
 
 from sklearn.model_selection import train_test_split, StratifiedShuffleSplit
@@ -147,7 +147,7 @@ class CVSearch:
         self,
         model: Any,
         dataset: MLSetup,
-        parameter_space: Dict[str, Iterable],
+        parameter_space: Dict[str, List[Union[int, float, str]]],
         random_search: bool = True,
         n_iterations: int = 30,
     ) -> Any:
@@ -198,14 +198,16 @@ class CVSearch:
         return best_model
 
     def get_random_search_setups(
-        self, parameter_space: Dict[str, Iterable], n_iterations: int
+        self,
+        parameter_space: Dict[str, List[Union[int, float, str]]],
+        n_iterations: int,
     ) -> List[Dict[str, Union[float, int, str]]]:
         """
         Create the parameter definitions over a parameter space randomly
 
         Parameters
         ----------
-        parameter_space: Dict[str, Iterable]
+        parameter_space: Dict[str, List[Union[int, float, str]]]
             A dictionary containing the parameter space setup, where the key is the parameter name, and the value is an Iterable of possible values.
 
         n_iterations: int
@@ -226,20 +228,18 @@ class CVSearch:
 
         return setups
 
-    def get_grid_search_setups(
-        parameter_space: Dict[str, Iterable]
-    ) -> List[Dict[str, Union[float, int, str]]]:
+    # def get_grid_search_setups(
+    #     parameter_space: Dict[str, Iterable]
+    # ) -> List[Dict[str, Union[float, int, str]]]:
 
-        # First, setup an index range dictionary for each of the parameters
-        param_ranges = {param: len(vals) for param, vals in parameter_space.items()}
-
-        # Next, create the
+    #     # TODO
+    #     return
 
     def validated_train(
         self,
         model: Any,
         data: MLSetup,
-        splits: List[np.ndarray[int]],
+        splits: List[np.ndarray],
         params: Dict[str, Union[int, float, str]],
         iteration: int,
     ) -> float:

--- a/mlexpy/pipeline_utils.py
+++ b/mlexpy/pipeline_utils.py
@@ -1,11 +1,11 @@
 import numpy as np
 import pandas as pd
 import logging
-from typing import Any, Dict, Callable, Union, List, Tuple
+from typing import Any, Dict, Callable, Union, List
 from collections import namedtuple
 from itertools import product
 
-from sklearn.model_selection import train_test_split, StratifiedShuffleSplit
+from sklearn.model_selection import StratifiedShuffleSplit, train_test_split
 
 
 logging.basicConfig(level=logging.INFO)
@@ -298,7 +298,7 @@ class CrossValidation:
         logger.info(
             f"Median score for iteration {iteration} {model_setup} is: {result_score}"
         )
-        return
+        return result_score
 
     def validated_eval(
         self,

--- a/mlexpy/pipeline_utils.py
+++ b/mlexpy/pipeline_utils.py
@@ -178,10 +178,18 @@ class CVSearch:
         cv_splitter = self.generate_splitter()
         split_indices = list(cv_splitter.split(dataset.obs, dataset.labels))
 
-        # Now, setup each model iterations, either as random search or grid search.
-        if random_search:
+        # Now, setup each model iterations, either as random search or grid search. But default to grid search if less than n_iterations.
+        setups = 1
+        for parameter_values in parameter_space.values():
+            setups *= len(parameter_values)
+
+        if random_search and setups > n_iterations:
             setups = self.get_random_search_setups(parameter_space, n_iterations)
         else:
+            if setups < n_iterations:
+                logger.info(
+                    f"Because there are less possible options ({setups}) than desired iterations ({n_iterations}), doing grid search."
+                )
             setups = self.get_grid_search_setups(parameter_space)
 
         # Next, iterate over the setups and compute the score

--- a/mlexpy/pipeline_utils.py
+++ b/mlexpy/pipeline_utils.py
@@ -1,10 +1,10 @@
 import numpy as np
 import pandas as pd
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, Callable, Any, Iterable, Union, List, Tuple
 from collections import namedtuple
 
-from sklearn.model_selection import train_test_split
+from sklearn.model_selection import train_test_split, StratifiedShuffleSplit
 
 
 logging.basicConfig(level=logging.INFO)
@@ -96,3 +96,140 @@ def cv_report(results: Dict[str, Any], n_top: int = 5) -> None:
                 f"""Mean validation score: {results["mean_test_score"][candidate]} (std: {results["std_test_score"][candidate]})"""
             )
             print(f"""Parameters: {results["params"][candidate]}\n""")
+
+
+class CVSearch:
+    """A class to perform cross validated evaluation and training for any given ml model."""
+
+    def __init__(
+        self,
+        score_function: Callable,
+        test_fraction: float,
+        n_splits: int = 5,
+        random_state: np.random.RandomState = np.random.RandomState(10),
+    ) -> None:
+
+        # set a default split function
+        self._split_method = StratifiedShuffleSplit
+
+        self.scorer = score_function
+        self.cv_splits = n_splits
+        self.rnd = random_state
+        self.test_frac = test_fraction
+
+    def set_split_function(self, split_function: Callable) -> None:
+        logger.info(f"Set the cv split method as {split_function}")
+        self._split_method = split_function
+
+    def generate_splitter(self) -> Any:
+        """
+        Generate a sklearn cv split model for the dataset.
+
+        Parameters
+        ----------
+        split_function: Any
+            The function to use to generate the cv_splits. Expecting some sort of sklearn split generator, but can be any.
+
+        Returns
+        -------
+            Any  (Returns the performed cv_split creator.)
+        """
+        return self._split_method(
+            n_splits=self.cv_splits, test_size=self.test_frac, random_state=self.rnd
+        )
+
+    def train_model(
+        self,
+        model: Any,
+        dataset: MLSetup,
+        parameter_space: Dict[str, Iterable],
+        random_search: bool = True,
+        n_iterations: int = 30,
+    ) -> Any:
+        """
+        Perform cross validated model training.
+
+        Parameters
+        ----------
+        model: Any
+            This is a model that you would like to train. Can be ANY model that has at minimum a fit, and a predict method.
+
+        dataset: MLSetup
+            This is the named tuple containing the train and test data.
+
+        random_search: bool
+            A boolean flag to delineate between random cv_search, and grid search. Default is random.
+
+        n_iterations: int
+            The number of random iterations to perform if random cv search is chosen. Default is 30
+
+        Return
+        ------
+            Any  (The best trained model over all iterations)
+        """
+
+        # First, setup temporary data...
+        result_models = {}
+        result_scores = []
+
+        # ... and the cv spliter.
+        cv_splitter = self.generate_splitter()
+
+        # Now, setup each model iterations, either as random search or grid search.
+        if random_search:
+            setups = self.get_random_search_setups(parameter_space, n_iterations)
+        else:
+            # create the grid search setups:
+            pass
+
+        # Next, iterate over the setups...
+        for setup in setups:
+            # ... and perform the cross validated training
+            score, trained_model = self.validated_train(model, dataset, cv_splitter)
+
+            pass
+
+    def get_random_search_setups(
+        self, parameter_space: Dict[str, Iterable], n_iterations: int
+    ) -> List[Dict[str, Union[float, int, str]]]:
+        """
+        Create the parameter definitions over a parameter space randomly
+
+        Parameters
+        ----------
+        parameter_space: Dict[str, Iterable]
+            A dictionary containing the parameter space setup, where the key is the parameter name, and the value is an Iterable of possible values.
+
+        n_iterations: int
+            The number of random setups to generate
+
+        Return
+        ------
+        List[Dict[str, Union[float, int, str]]]
+        """
+
+        # Create the setups
+        setups = []
+        for _ in range(n_iterations):
+            setup = {
+                param: self.rnd.choice(vals) for param, vals in parameter_space.items()
+            }
+            setups.append(setup)
+
+        return setup
+
+    def get_grid_search_setups(
+        parameter_space: Dict[str, Iterable]
+    ) -> List[Dict[str, Union[float, int, str]]]:
+
+        # First, setup an index range dictionary for each of the parameters
+        param_ranges = {param: len(vals) for param, vals in parameter_space.items()}
+
+        # Next, create the
+
+    def validated_train(
+        self, model: Any, data: MLSetup, cv_splitter: Any
+    ) -> Tuple[float, Any]:
+
+        bp = 1
+        pass

--- a/mlexpy/pipeline_utils.py
+++ b/mlexpy/pipeline_utils.py
@@ -116,7 +116,6 @@ class CVSearch:
         self.scorer = score_function
         self.cv_splits = n_splits
         self.rnd = np.random.RandomState(random_seed)
-        self.random_seed = random_seed
         self.test_frac = test_fraction
 
     def set_split_function(self, split_function: Callable) -> None:
@@ -194,7 +193,7 @@ class CVSearch:
 
         # ... get the best scoring setup, and retrain over all data.
         best_score_idx = np.argmin(model_scores)
-        best_model = model(random_state=self.random_seed, **setups[best_score_idx])
+        best_model = model(**setups[best_score_idx])
         best_model.fit(dataset.obs, dataset.labels)
         return best_model
 
@@ -259,7 +258,7 @@ class CVSearch:
         # Setup the model to train
         scores = []
         for split in splits:
-            model_setup = model(random_state=self.random_seed, **params)
+            model_setup = model(**params)
             # Get the split specific dataset...
             cv_train_obs, cv_train_labels = (
                 data.obs.iloc[split[0]],

--- a/tests/test_crossvalidation.py
+++ b/tests/test_crossvalidation.py
@@ -1,0 +1,98 @@
+import pytest
+from fixtures import simple_binary_dataframe, simple_series, simple_dataframe
+from mlexpy.pipeline_utils import CrossValidation, MLSetup
+from pandas.testing import assert_frame_equal
+import numpy as np
+from sklearn.metrics import f1_score, mean_squared_error
+
+f1_metric = lambda labels, preds: -f1_score(labels, preds, average="macro")
+
+rmse = lambda labels, preds: np.sqrt(mean_squared_error(labels, preds))
+
+
+@pytest.fixture
+def model_definitions():
+
+    return {
+        "param1": [1, 2, 3, 4, 5],
+        "param2": [1.2, 1.3, 1.4, 0.1],
+        "param3": ["a", "b", "c"],
+    }
+
+
+def get_simple_cv(cv_split_frac, random_iterations, random_seed, score_function):
+
+    random_state = np.random.RandomState(random_seed)
+
+    return CrossValidation(
+        test_fraction=cv_split_frac,
+        score_function=score_function,
+        n_splits=random_iterations,
+        random_seed=random_state.get_state(legacy=False)["state"]["key"][
+            -1
+        ],  # needs to be an integer here
+    )
+
+
+def test_cv_splitting(simple_binary_dataframe):
+    """Test that basic functionality of the cross validation tooling."""
+
+    # First, test that the same seed results in the same splits.
+    cv1 = get_simple_cv(0.5, 5, 10, f1_metric)
+    splitter_1 = cv1.generate_splitter()
+
+    cv2 = get_simple_cv(0.5, 5, 10, f1_metric)
+    splitter_2 = cv2.generate_splitter()
+
+    cv3 = get_simple_cv(0.5, 5, 100, f1_metric)
+    splitter_3 = cv3.generate_splitter()
+
+    # assert splitter_1 == splitter_2
+    # "The splitter objects are NOT the same when initializing the SAME cv_splitter object."
+    # assert splitter_1 != splitter_3
+    # "The splitter objects ARE the same when initializing DIFFERENT cv_splitter objects."
+
+    # Next, test that the actual data are different or the same if desired.
+    dataobj = MLSetup(
+        simple_binary_dataframe[["obs1", "obs2"]], simple_binary_dataframe["target"]
+    )
+
+    idcs_1 = list(splitter_1.split(dataobj.obs, dataobj.labels))
+    idcs_2 = list(splitter_2.split(dataobj.obs, dataobj.labels))
+    idcs_3 = list(splitter_3.split(dataobj.obs, dataobj.labels))
+
+    print(idcs_1[0][0])
+    print(idcs_2[0][0])
+    print(idcs_3[0][0])
+
+    assert all([i_1 == idcs_2[0][0][i] for i, i_1 in enumerate(idcs_1[0][0])])
+    "The splitter data are NOT the same when initializing the SAME cv_splitter object."
+    assert any([i_1 != idcs_3[0][0][i] for i, i_1 in enumerate(idcs_1[0][0])])
+    "The splitter data ARE the same when initializing DIFFERENT cv_splitter objects."
+
+
+def test_parameter_space(model_definitions):
+
+    cv1 = get_simple_cv(0.5, 5, 10, f1_metric)
+    cv2 = get_simple_cv(0.5, 5, 10, f1_metric)
+    cv3 = get_simple_cv(0.5, 5, 100, f1_metric)
+
+    space_1 = cv1.get_random_search_setups(model_definitions, 5)
+    space_2 = cv2.get_random_search_setups(model_definitions, 5)
+    space_3 = cv3.get_random_search_setups(model_definitions, 5)
+
+    # Test that we don't create the same parameter spaces when we do and dont want to.
+    assert space_1 == space_2
+    "The parameter space options are NOT the same when initializing the SAME cv_splitter object."
+    assert space_1 != space_3
+    "The parameter space options ARE the same when initializing DIFFERENT cv_splitter objects."
+
+    # Test that we create the correct number of options using grid search.
+    option_count = 1
+    for values in model_definitions.values():
+        option_count *= len(values)
+
+    grid_space = cv1.get_grid_search_setups(model_definitions)
+
+    assert option_count == len(grid_space)
+    "The number of setups in the grid search result is not equal to all possible setups."

--- a/tests/test_ml_examples.py
+++ b/tests/test_ml_examples.py
@@ -502,13 +502,38 @@ def test_cv_classification_model_match(
         ]
     )
 
-    # Test that I can create probabs...
-    probabilities = experiment_obj.predict(
-        processed_datasets, trained_model, proba=True
-    )
-    # ... and that they can be evaluated...
-    experiment_obj.evaluate_predictions(
-        processed_datasets.test_data.labels,
+    # Test that I can do cv evaluations twice
+
+    cv_eval_1 = experiment_obj.evaluate_predictions_cross_validation(
+        metric_function=experiment_obj.metric_dict["log_loss"],
         predictions=predictions,
-        class_probabilities=probabilities,
+        data=processed_datasets.test_data,
+        random_iterations=5,
     )
+    cv_eval_2 = experiment_obj.evaluate_predictions_cross_validation(
+        metric_function=experiment_obj.metric_dict["log_loss"],
+        predictions=predictions,
+        data=processed_datasets.test_data,
+        random_iterations=5,
+    )
+    cv_eval_3 = new_experiment.evaluate_predictions_cross_validation(
+        metric_function=experiment_obj.metric_dict["log_loss"],
+        predictions=new_predictions,
+        data=processed_datasets.test_data,
+        random_iterations=5,
+    )
+
+    # make sure that these 2 evals have he same values
+    assert cv_eval_1.mean == cv_eval_2.mean
+    "The mean of the 2 evaluation scores is not the same when it should be."
+    assert cv_eval_1.median == cv_eval_2.median
+    "The median of the 2 evaluation scores is not the same when it should be."
+    assert cv_eval_1.std == cv_eval_2.std
+    "The standard deviation of the 2 evaluation scores is not the same when it should be."
+
+    assert cv_eval_1.mean == cv_eval_3.mean
+    "The mean of the 2 evaluation scores is not the same when it should be with a loaded model."
+    assert cv_eval_1.median == cv_eval_3.median
+    "The median of the 2 evaluation scores is not the same when it should be with a loaded model."
+    assert cv_eval_1.std == cv_eval_3.std
+    "The standard deviation of the 2 evaluation scores is not the same when it should be with a loaded model."

--- a/tests/test_ml_examples.py
+++ b/tests/test_ml_examples.py
@@ -8,6 +8,7 @@ from xgboost import XGBClassifier
 import sys
 from numpy.testing import assert_array_equal
 from fixtures import simple_dataframe, simple_binary_dataframe, rs_10, rs_20
+from sklearn.model_selection import ShuffleSplit, StratifiedShuffleSplit
 
 
 @pytest.fixture
@@ -281,4 +282,233 @@ def test_classification_model_match(
 
     experiment_obj.plot_multiclass_roc(
         processed_datasets.test_data.labels, probabilities
+    )
+
+
+def test_cv_regression_model_match(simple_dataframe, rs_10, rs_20, basic_processor):
+
+    # Now do the experiment...
+
+    dataset = pipeline_utils.get_stratified_train_test_data(
+        simple_dataframe[["obs1", "obs2"]],
+        simple_dataframe["target"],
+        test_frac=0.5,
+        random_state=rs_20,
+        stratify=False,
+    )
+    experiment_obj = experiment.RegressionExperiment(
+        train_setup=dataset.train_data,
+        test_setup=dataset.test_data,
+        model_tag="regression_match_model",
+        process_tag="regression_match_process",
+    )
+
+    experiment_obj.set_pipeline(basic_processor)
+
+    # Now begin the experimentation, start with performing the data processing...
+    processed_datasets = experiment_obj.process_data()
+
+    # ... then train our model...
+    trained_model = experiment_obj.cv_train(
+        data_setup=processed_datasets,
+        ml_model=RandomForestRegressor,
+        parameters={
+            "n_estimators": [10, 50, 100, 200],
+            "max_depth": [1, 5, 10, 20, 50],
+            "random_state": [rs_10],
+        },
+        cv_split_function=ShuffleSplit,
+    )
+    # Get the predictions and evaluate the performance.
+    predictions = experiment_obj.predict(processed_datasets, trained_model)
+    results = experiment_obj.evaluate_predictions(
+        processed_datasets.test_data.labels,
+        predictions=predictions,
+    )
+
+    # Here we store the model
+    experiment_obj.store_model(trained_model)
+
+    # Now, test that the results are the same if loading from a disk.
+    loaded_datasets = experiment_obj.process_data_from_stored_models()
+    loaded_model = experiment_obj.load_model()
+    # Get the predictions and evaluate the performance.
+    loaded_predictions = experiment_obj.predict(loaded_datasets, loaded_model)
+    loaded_results = experiment_obj.evaluate_predictions(
+        loaded_datasets.test_data.labels,
+        predictions=loaded_predictions,
+    )
+
+    # Assert that the predictions are the same
+    assert_array_equal(predictions, loaded_predictions)
+
+    # Assert that the evaluation metrics are all the same
+    assert all(
+        [
+            trained_value == loaded_results[trained_key]
+            for trained_key, trained_value in results.items()
+        ]
+    )
+
+    # Do the same thing with a newly named class
+    new_experiment = experiment.RegressionExperiment(
+        train_setup=dataset.train_data,
+        test_setup=dataset.test_data,
+        model_tag="regression_match_model",
+        process_tag="regression_match_process",
+    )
+    new_experiment.set_pipeline(basic_processor)
+    new_datasets = new_experiment.process_data_from_stored_models()
+    new_model = new_experiment.load_model()
+
+    # Get the predictions and evaluate the performance.
+    new_predictions = new_experiment.predict(new_datasets, new_model)
+    new_results = new_experiment.evaluate_predictions(
+        new_datasets.test_data.labels,
+        predictions=new_predictions,
+    )
+
+    # Assert that the predictions are the same
+    assert_array_equal(predictions, new_predictions)
+
+    # Assert that the evaluation metrics are all the same
+    assert all(
+        [
+            trained_value == new_results[trained_key]
+            for trained_key, trained_value in results.items()
+        ]
+    )
+
+
+def test_cv_classification_model_match(
+    simple_binary_dataframe, rs_10, rs_20, basic_processor
+):
+
+    # Now do the experiment...
+    dataset = pipeline_utils.get_stratified_train_test_data(
+        simple_binary_dataframe[["obs1", "obs2"]],
+        simple_binary_dataframe["target"],
+        test_frac=0.5,
+        random_state=rs_20,
+    )
+    experiment_obj = experiment.ClassifierExperiment(
+        train_setup=dataset.train_data,
+        test_setup=dataset.test_data,
+        model_tag="classification_match_model",
+        process_tag="classification_match_process",
+    )
+
+    experiment_obj.set_pipeline(basic_processor)
+
+    # Now begin the experimentation, start with performing the data processing...
+    processed_datasets = experiment_obj.process_data()
+
+    # ... then train our model...
+    trained_model = experiment_obj.cv_train(
+        data_setup=processed_datasets,
+        ml_model=RandomForestClassifier,
+        parameters={
+            "n_estimators": [10, 50, 100, 200],
+            "max_depth": [1, 5, 10, 20, 50],
+            "criterion": ["gini", "entropy", "log_loss"],
+            "random_state": [rs_10],
+        },
+    )
+    # Get the predictions and evaluate the performance.
+    predictions = experiment_obj.predict(processed_datasets, trained_model)
+    results = experiment_obj.evaluate_predictions(
+        processed_datasets.test_data.labels,
+        predictions=predictions,
+    )
+
+    # Here we store the model
+    experiment_obj.store_model(trained_model)
+
+    # Now, test that the results are the same if loading from a disk.
+    loaded_datasets = experiment_obj.process_data_from_stored_models()
+    loaded_model = experiment_obj.load_model(RandomForestClassifier())
+    # Get the predictions and evaluate the performance.
+
+    loaded_predictions = experiment_obj.predict(loaded_datasets, loaded_model)
+    loaded_results = experiment_obj.evaluate_predictions(
+        loaded_datasets.test_data.labels,
+        predictions=loaded_predictions,
+    )
+
+    # Assert that the predictions are the same
+    assert_array_equal(predictions, loaded_predictions)
+
+    # Assert that the evaluation metrics are all the same
+    assert all(
+        [
+            results[key] == loaded_results[key]
+            for key in [
+                "f1_micro",
+                "f1_macro",
+                "log_loss",
+                "accuracy",
+                "balanced_accuracy",
+                "f1_weighted",
+            ]
+        ]
+    )
+
+    # Do the same thing with a newly named class
+    new_experiment = experiment.ClassifierExperiment(
+        train_setup=dataset.train_data,
+        test_setup=dataset.test_data,
+        model_tag="classification_match_model",
+        process_tag="classification_match_process",
+    )
+    new_experiment.set_pipeline(basic_processor)
+    new_datasets = new_experiment.process_data_from_stored_models()
+    new_model = new_experiment.load_model(RandomForestClassifier())
+
+    # Get the predictions and evaluate the performance.
+    new_predictions = new_experiment.predict(new_datasets, new_model)
+    new_results = new_experiment.evaluate_predictions(
+        new_datasets.test_data.labels,
+        predictions=new_predictions,
+    )
+
+    # Assert that the predictions are the same
+    assert_array_equal(predictions, new_predictions)
+
+    # Assert that the evaluation metrics are all the same
+    print(
+        [
+            results[key] == new_results[key]
+            for key in [
+                "f1_micro",
+                "f1_macro",
+                "log_loss",
+                "accuracy",
+                "balanced_accuracy",
+                "f1_weighted",
+            ]
+        ]
+    )
+    assert all(
+        [
+            results[key] == new_results[key]
+            for key in [
+                "f1_micro",
+                "f1_macro",
+                "log_loss",
+                "accuracy",
+                "balanced_accuracy",
+                "f1_weighted",
+            ]
+        ]
+    )
+
+    # Test that I can create probabs...
+    probabilities = experiment_obj.predict(
+        processed_datasets, trained_model, proba=True
+    )
+    # ... and that they can be evaluated...
+    experiment_obj.evaluate_predictions(
+        processed_datasets.test_data.labels,
+        predictions=predictions,
+        class_probabilities=probabilities,
     )

--- a/tests/test_ml_examples.py
+++ b/tests/test_ml_examples.py
@@ -84,9 +84,8 @@ def test_regression_model_match(simple_dataframe, rs_10, rs_20, basic_processor)
     processed_datasets = experiment_obj.process_data()
 
     # ... then train our model...
-    trained_model = experiment_obj.train_model(
-        RandomForestRegressor(random_state=rs_10),
-        processed_datasets,
+    trained_model = experiment_obj.one_shot_train(
+        RandomForestRegressor, processed_datasets, parameters={"random_state": rs_10}
     )
     # Get the predictions and evaluate the performance.
     predictions = experiment_obj.predict(processed_datasets, trained_model)
@@ -173,9 +172,8 @@ def test_classification_model_match(
     processed_datasets = experiment_obj.process_data()
 
     # ... then train our model...
-    trained_model = experiment_obj.train_model(
-        XGBClassifier(random_state=rs_10),
-        processed_datasets,
+    trained_model = experiment_obj.one_shot_train(
+        XGBClassifier, processed_datasets, parameters={"random_state": rs_10}
     )
     # Get the predictions and evaluate the performance.
     predictions = experiment_obj.predict(processed_datasets, trained_model)


### PR DESCRIPTION
WIP Draft PR of adding tooling to perform cross-validation within `mlexpy`. Previously CV was done via `sklearn`. However, this was a little bit limiting in the structure of models that could be used. Doing CV inside of `mlexpy` is directed toward acieving 2 main goals:
1. Allowing for a much more permissive definition of models that are fully functional in the `mlexpy` framework (specifically, any model that has a `.fit()` and a `.perdict()` method, regardless of what those methods actually do.
2. Abstracting different cross-validated evaluation steps out of the cross-validated training tooling, providing a more robust ability to evaluate models, even if not performing cross-validated training.

Little functionality changes, however, a specific point of note is the way random seeds are provided to models. Now, _every_ model passed to the `experiment.cv_train()` or `experiment.one_shot_train()` methods are passed as the class, ***not*** as a class instance, and a parameters dictionary must be passed as well defining the random seed to the model (if the model is stochastic).

Training a model will now raise an exception if no parameters are provided.
